### PR TITLE
feat: conditionally animate discord assets

### DIFF
--- a/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/dms/details/page.tsx
+++ b/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/dms/details/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { useNetworkState } from "react-use";
 import ProfileHeader from "~/components/ProfileHeader";
@@ -16,6 +15,7 @@ import NoDataAvailable from "~/components/NoDataAvailable";
 import NotFoundState from "~/components/NotFoundState";
 import { formatDate, formatHour, formatNumber } from "~/utils/format";
 import SentimentScore from "./_components/SentimentScore";
+import DiscordImage from "~/components/DiscordImage";
 
 export default function Page() {
   const params = useSearchParams()!;
@@ -58,7 +58,7 @@ export default function Page() {
         title={displayName}
         imageSlot={
           <div className="relative h-16 w-16 sm:h-32 sm:w-32">
-            <Image
+            <DiscordImage
               src={
                 avatarURLFallback(avatarURL, user.dm_user_id) + `?size=${size}`
               }

--- a/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/guilds/details/_components/Profile.tsx
+++ b/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/guilds/details/_components/Profile.tsx
@@ -6,9 +6,9 @@ import { SimpleIconsDiscord } from "~/components/icons";
 import type { Guild } from "~/types/sql";
 import useWidgetAPI from "~/hooks/use-widget-api";
 import { useQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import { iconColor } from "~/utils/discord";
 import { firstCharFromUnicode } from "~/utils";
+import DiscordImage from "~/components/DiscordImage";
 
 export default function Profile({
   guild,
@@ -36,7 +36,7 @@ export default function Profile({
       imageSlot={
         isSuccess && data.error === undefined ? (
           <div className="relative aspect-square w-16 sm:w-32">
-            <Image
+            <DiscordImage
               src={data.icon_url}
               alt={`${data.name}'s avatar`}
               fill

--- a/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/guilds/details/_components/TopUsedBots.tsx
+++ b/src/app/[locale]/(app)/(nav)/(time-selector)/(top)/top/guilds/details/_components/TopUsedBots.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import Section from "~/components/Section";
 import StatCard from "~/components/data/StatCard";
 import usePackageAPI from "~/hooks/use-package-api";
 import { useSelectedPackage } from "~/stores";
 import { Activity, DmChannelsData } from "~/types/sql";
 import { avatarURLFallback } from "~/utils/discord";
+import DiscordImage from "~/components/DiscordImage";
 
 type Bot = Pick<
   DmChannelsData,
@@ -37,7 +37,7 @@ function BotCard({ bot }: { bot: Bot }) {
       value={
         <div className="flex items-center">
           <div className="relative mr-1 aspect-square w-6 sm:w-8">
-            <Image
+            <DiscordImage
               src={avatarURLFallback(avatarURL, bot.associated_user_id)}
               alt={`${displayName}'s avatar`}
               fill

--- a/src/app/[locale]/(app)/(nav)/(time-selector)/top/dms/_components/TopDmsList.tsx
+++ b/src/app/[locale]/(app)/(nav)/(time-selector)/top/dms/_components/TopDmsList.tsx
@@ -2,7 +2,6 @@
 
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import NoDataAvailable from "~/components/NoDataAvailable";
 import DetailCard from "~/components/data/DetailCard";
 import useTopDMsData from "~/hooks/data/use-top-dms-data";
@@ -11,6 +10,7 @@ import { useAppStore } from "~/stores";
 import { avatarURLFallback } from "~/utils/discord";
 import { formatNumber } from "~/utils/format";
 import LoadMore from "../../_components/LoadMore";
+import DiscordImage from "~/components/DiscordImage";
 
 function DMCard({
   dm,
@@ -31,7 +31,7 @@ function DMCard({
       description={`${formatNumber(dm.message_count)} messages sent`}
       leftSlot={
         <div className="relative aspect-square w-10">
-          <Image
+          <DiscordImage
             src={avatarURLFallback(avatarURL, dm.dm_user_id)}
             alt={`${username}'s avatar`}
             fill

--- a/src/app/[locale]/(app)/(nav)/(time-selector)/top/guilds/_components/TopGuildsList.tsx
+++ b/src/app/[locale]/(app)/(nav)/(time-selector)/top/guilds/_components/TopGuildsList.tsx
@@ -2,7 +2,6 @@
 
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import NoDataAvailable from "~/components/NoDataAvailable";
 import DetailCard from "~/components/data/DetailCard";
 import useTopGuildsData from "~/hooks/data/use-top-guilds-data";
@@ -12,6 +11,7 @@ import { firstCharFromUnicode } from "~/utils";
 import { iconColor } from "~/utils/discord";
 import { formatNumber } from "~/utils/format";
 import LoadMore from "../../_components/LoadMore";
+import DiscordImage from "~/components/DiscordImage";
 
 function GuildCard({
   guild,
@@ -37,7 +37,7 @@ function GuildCard({
       leftSlot={
         isSuccess && data.error === undefined ? (
           <div className="relative aspect-square w-10">
-            <Image
+            <DiscordImage
               src={data.icon_url}
               alt={`${data.name}'s avatar`}
               fill

--- a/src/app/[locale]/(app)/(nav)/overview/_components/Profile.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/Profile.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { useNetworkState } from "react-use";
 import Button from "~/components/Button";
+import DiscordImage from "~/components/DiscordImage";
 import ProfileHeader from "~/components/ProfileHeader";
 import useUserData from "~/hooks/data/use-user-data";
 import { useAppStore } from "~/stores";
@@ -37,7 +37,7 @@ export default function Profile() {
       title={package_owner_display_name}
       imageSlot={
         <div className="relative h-24 w-24 sm:h-32 sm:w-32">
-          <Image
+          <DiscordImage
             src={package_owner_avatar_url + `?size=${size}`}
             alt={`${package_owner_display_name}'s Avatar`}
             fill

--- a/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useNetworkState } from "react-use";
 import ScrollArea from "~/components/ScrollArea";
 import Section from "~/components/Section";
@@ -9,7 +8,7 @@ import useTopDMsData from "~/hooks/data/use-top-dms-data";
 import useUserDetails from "~/hooks/use-user-details";
 import { avatarURLFallback } from "~/utils/discord";
 import { useTranslation } from "~/i18n/client";
-import useFocus from "~/hooks/use-focus";
+import DiscordImage from "~/components/DiscordImage";
 
 function DMCard({
   dm,
@@ -22,14 +21,7 @@ function DMCard({
 
   const username = dm.user_name;
   const displayName = data?.display_name || username;
-  const userDataAvatar = data?.avatar_url || dm.user_avatar_url;
-  const focused = useFocus();
-  const avatarURL = !userDataAvatar?.includes(".gif")
-    ? userDataAvatar
-    : userDataAvatar.replace(
-        focused ? ".webp" : ".gif",
-        focused ? ".gif" : ".webp"
-      );
+  const avatarURL = data?.avatar_url || dm.user_avatar_url;
 
   return (
     <AvatarCard
@@ -39,7 +31,7 @@ function DMCard({
       href={`/top/dms/details?id=${dm.dm_user_id}`}
       image={
         <div className="relative aspect-square w-full">
-          <Image
+          <DiscordImage
             src={avatarURLFallback(avatarURL, dm.dm_user_id) + `?size=${size}`}
             alt={`${username}'s avatar`}
             fill

--- a/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
@@ -27,8 +27,8 @@ function DMCard({
   const avatarURL = !userDataAvatar?.includes(".gif")
     ? userDataAvatar
     : userDataAvatar.replace(
-        focused ? ".png" : ".gif",
-        focused ? ".gif" : ".png"
+        focused ? ".webp" : ".gif",
+        focused ? ".gif" : ".webp"
       );
 
   return (

--- a/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/TopDMs.tsx
@@ -9,6 +9,7 @@ import useTopDMsData from "~/hooks/data/use-top-dms-data";
 import useUserDetails from "~/hooks/use-user-details";
 import { avatarURLFallback } from "~/utils/discord";
 import { useTranslation } from "~/i18n/client";
+import useFocus from "~/hooks/use-focus";
 
 function DMCard({
   dm,
@@ -21,7 +22,14 @@ function DMCard({
 
   const username = dm.user_name;
   const displayName = data?.display_name || username;
-  const avatarURL = data?.avatar_url || dm.user_avatar_url;
+  const userDataAvatar = data?.avatar_url || dm.user_avatar_url;
+  const focused = useFocus();
+  const avatarURL = !userDataAvatar?.includes(".gif")
+    ? userDataAvatar
+    : userDataAvatar.replace(
+        focused ? ".png" : ".gif",
+        focused ? ".gif" : ".png"
+      );
 
   return (
     <AvatarCard
@@ -44,7 +52,6 @@ function DMCard({
 }
 
 export default function TopDMs() {
-  
   const { t } = useTranslation();
 
   const data = useTopDMsData().getData({});
@@ -64,7 +71,7 @@ export default function TopDMs() {
   })();
 
   return (
-    <Section title={t('mostActiveDMs')} href="/top/dms">
+    <Section title={t("mostActiveDMs")} href="/top/dms">
       <ScrollArea orientation="horizontal">
         <div className="flex">
           {(data || []).map((dm) => (

--- a/src/app/[locale]/(app)/(nav)/overview/_components/TopGuilds.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/TopGuilds.tsx
@@ -10,6 +10,7 @@ import useWidgetAPI from "~/hooks/use-widget-api";
 import { firstCharFromUnicode } from "~/utils";
 import { iconColor } from "~/utils/discord";
 import { useTranslation } from "~/i18n/client";
+import useFocus from "~/hooks/use-focus";
 
 function GuildCard({
   guild,
@@ -26,6 +27,8 @@ function GuildCard({
     staleTime: Infinity,
   });
 
+  const focused = useFocus();
+
   return (
     <AvatarCard
       name={guild.guild_name}
@@ -36,7 +39,14 @@ function GuildCard({
         isSuccess && data.error === undefined ? (
           <div className="relative aspect-square w-full">
             <Image
-              src={data.icon_url}
+              src={
+                data.icon_url.includes(".gif")
+                  ? data.icon_url.replace(
+                      focused ? ".webp" : ".gif",
+                      focused ? ".gif" : ".webp"
+                    )
+                  : data.icon_url
+              }
               alt={`${data.name}'s avatar`}
               fill
               className="rounded-lg object-cover object-center"
@@ -62,7 +72,7 @@ export default function TopGuilds() {
   const data = useTopGuildsData().getData({});
 
   return (
-    <Section title={t('mostActiveServers')} href="/top/guilds">
+    <Section title={t("mostActiveServers")} href="/top/guilds">
       <ScrollArea orientation="horizontal">
         <div className="flex">
           {(data || []).map((guild) => (

--- a/src/app/[locale]/(app)/(nav)/overview/_components/TopGuilds.tsx
+++ b/src/app/[locale]/(app)/(nav)/overview/_components/TopGuilds.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import Image from "next/image";
 import ScrollArea from "~/components/ScrollArea";
 import Section from "~/components/Section";
 import AvatarCard from "~/components/data/AvatarCard";
@@ -10,7 +9,7 @@ import useWidgetAPI from "~/hooks/use-widget-api";
 import { firstCharFromUnicode } from "~/utils";
 import { iconColor } from "~/utils/discord";
 import { useTranslation } from "~/i18n/client";
-import useFocus from "~/hooks/use-focus";
+import DiscordImage from "~/components/DiscordImage";
 
 function GuildCard({
   guild,
@@ -27,8 +26,6 @@ function GuildCard({
     staleTime: Infinity,
   });
 
-  const focused = useFocus();
-
   return (
     <AvatarCard
       name={guild.guild_name}
@@ -38,15 +35,8 @@ function GuildCard({
       image={
         isSuccess && data.error === undefined ? (
           <div className="relative aspect-square w-full">
-            <Image
-              src={
-                data.icon_url.includes(".gif")
-                  ? data.icon_url.replace(
-                      focused ? ".webp" : ".gif",
-                      focused ? ".gif" : ".webp"
-                    )
-                  : data.icon_url
-              }
+            <DiscordImage
+              src={data.icon_url}
               alt={`${data.name}'s avatar`}
               fill
               className="rounded-lg object-cover object-center"

--- a/src/components/DiscordImage.tsx
+++ b/src/components/DiscordImage.tsx
@@ -6,6 +6,7 @@ import useFocus from "~/hooks/use-focus";
 type DiscordImageProps = React.ComponentProps<typeof Image>;
 
 export default function DiscordImage(props: DiscordImageProps) {
+  const { src, ...rest } = props;
   const focused = useFocus();
 
   const imageSrc =
@@ -20,5 +21,5 @@ export default function DiscordImage(props: DiscordImageProps) {
       : src;
 
   // eslint-disable-next-line
-  return <Image {...props} src={imageSrc} />;
+  return <Image {...rest} src={imageSrc} />;
 }

--- a/src/components/DiscordImage.tsx
+++ b/src/components/DiscordImage.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Image from "next/image";
+import useFocus from "~/hooks/use-focus";
+
+type DiscordImageProps = React.ComponentProps<typeof Image>;
+
+export default function DiscordImage(props: DiscordImageProps) {
+  const focused = useFocus();
+
+  const imageSrc =
+    typeof props.src === "string" &&
+    // ignore placeholders
+    !props.src.includes("/embed") &&
+    props.src.includes(".gif")
+      ? props.src.replace(
+          focused ? ".webp" : ".gif",
+          focused ? ".gif" : ".webp"
+        )
+      : props.src;
+
+  // eslint-disable-next-line
+  return <Image {...props} src={imageSrc} />;
+}

--- a/src/components/DiscordImage.tsx
+++ b/src/components/DiscordImage.tsx
@@ -9,15 +9,15 @@ export default function DiscordImage(props: DiscordImageProps) {
   const focused = useFocus();
 
   const imageSrc =
-    typeof props.src === "string" &&
+    typeof src === "string" &&
     // ignore placeholders
-    !props.src.includes("/embed") &&
-    props.src.includes(".gif")
-      ? props.src.replace(
+    !src.includes("/embed") &&
+    src.includes(".gif")
+      ? src.replace(
           focused ? ".webp" : ".gif",
           focused ? ".gif" : ".webp"
         )
-      : props.src;
+      : src;
 
   // eslint-disable-next-line
   return <Image {...props} src={imageSrc} />;

--- a/src/components/DiscordImage.tsx
+++ b/src/components/DiscordImage.tsx
@@ -20,6 +20,7 @@ export default function DiscordImage(props: DiscordImageProps) {
         )
       : src;
 
+  // TODO: check why alt is not detected
   // eslint-disable-next-line
   return <Image {...rest} src={imageSrc} />;
 }

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type OnFocusChangeHandler = (focused: boolean) => unknown;
+
+export default function useFocus<E extends HTMLElement>(
+  target?: React.RefObject<E> | null,
+  onFocusChange?: OnFocusChangeHandler
+) {
+  const [focused, setFocused] = useState(() => {
+    return window.document.activeElement != null;
+  });
+
+  useEffect(() => {
+    onFocusChange?.(focused);
+  }, [focused, onFocusChange]);
+
+  useEffect(() => {
+    const focusTarget = target?.current ?? window;
+
+    const blurListener = () => {
+      setFocused(false);
+    };
+
+    const focusListener = () => {
+      setFocused(true);
+    };
+
+    focusTarget.addEventListener("blur", blurListener);
+    focusTarget.addEventListener("focus", focusListener);
+
+    return () => {
+      focusTarget.removeEventListener("blur", blurListener);
+      focusTarget.removeEventListener("focus", focusListener);
+    };
+  }, [target]);
+
+  return focused;
+}

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -6,7 +6,7 @@ type OnFocusChangeHandler = (focused: boolean) => unknown;
 
 export default function useFocus<E extends HTMLElement>(
   target?: React.RefObject<E> | null,
-  onFocusChange?: OnFocusChangeHandler
+  onFocusChange?: (focused: boolean) => void;
 ) {
   const [focused, setFocused] = useState(() => {
     return window.document.activeElement != null;

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 
 export default function useFocus<E extends HTMLElement>(
   target?: React.RefObject<E> | null,
-  onFocusChange?: (focused: boolean) => void;
+  onFocusChange?: (focused: boolean) => void
 ) {
   const [focused, setFocused] = useState(() => {
     return window.document.activeElement != null;

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -8,7 +8,7 @@ export default function useFocus<E extends HTMLElement>(
   onFocusChange?: (focused: boolean) => void
 ) {
   const [focused, setFocused] = useState(() => {
-    return window.document.activeElement != null;
+    return typeof window !== "undefined" ? window.document.activeElement != null : true;
   });
 
   useEffect(() => {

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 
-type OnFocusChangeHandler = (focused: boolean) => unknown;
 
 export default function useFocus<E extends HTMLElement>(
   target?: React.RefObject<E> | null,


### PR DESCRIPTION
This idea is inspired by Discord itself. When the window is focused, we render animated avatar, otherwise we render static avatar. Since the contributing guide is missing, I may have done something inappropriately. Please feel free to correct me if that's the case.

~~I haven't applied this to Guild icons, let me know if I should do that in this PR.~~
As per the conversation in Discord, I have replaced `<Image/>` with `<DiscordImage/>` for user avatars/guild icons.