### PR TITLE
feat: deploy web.dumpus.app to S3 + CloudFront

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,73 @@
+name: deploy-web
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "android/**"
+      - "ios/**"
+      - "src-tauri/**"
+      - "infra/**"
+      - "**.md"
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC
+  contents: read
+
+env:
+  AWS_REGION: eu-west-1
+  SITE_BUCKET: dumpus-web-site-prod
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.14.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build static site
+        run: pnpm build
+        env:
+          NODE_ENV: production
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync to S3
+        run: |
+          # Hashed assets — long cache, immutable.
+          aws s3 sync dist/ "s3://${SITE_BUCKET}/" \
+            --delete \
+            --exclude "*.html" \
+            --exclude "*.json" \
+            --cache-control "public, max-age=31536000, immutable"
+          # HTML + JSON — never cached so deploys take effect immediately.
+          aws s3 sync dist/ "s3://${SITE_BUCKET}/" \
+            --exclude "*" \
+            --include "*.html" \
+            --include "*.json" \
+            --cache-control "public, max-age=0, must-revalidate"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,60 @@
+name: infra
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        type: choice
+        description: "What to do"
+        options: [plan, apply]
+        default: plan
+
+permissions:
+  contents: read
+
+jobs:
+  infra:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: infra/terraform
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.8.5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.BOOTSTRAP_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BOOTSTRAP_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: tofu init
+        run: tofu init
+
+      - name: tofu plan
+        if: inputs.action == 'plan'
+        run: tofu plan -var-file=terraform.ci.tfvars -no-color
+
+      - name: tofu apply
+        if: inputs.action == 'apply'
+        run: tofu apply -auto-approve -var-file=terraform.ci.tfvars
+
+      - name: Outputs
+        if: inputs.action == 'apply'
+        run: |
+          {
+            echo "## Terraform outputs"
+            echo
+            echo '```'
+            tofu output
+            echo '```'
+            echo
+            echo "**Next**: copy \`github_deploy_role_arn\` into \`AWS_DEPLOY_ROLE_ARN\` repo secret."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+!terraform.ci.tfvars
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/acm.tf
+++ b/infra/terraform/acm.tf
@@ -1,0 +1,33 @@
+# CloudFront only accepts ACM certs from us-east-1 — pin the alias.
+resource "aws_acm_certificate" "web" {
+  provider          = aws.us_east_1
+  domain_name       = local.fqdn
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.web.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id         = data.aws_route53_zone.apex.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  ttl             = 60
+  records         = [each.value.record]
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "web" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.web.arn
+  validation_record_fqdns = [for r in aws_route53_record.acm_validation : r.fqdn]
+}

--- a/infra/terraform/backend.tf
+++ b/infra/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "dumpus-prod-tfstate"
+    key            = "web/prod/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "dumpus-prod-tfstate-lock"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/cloudfront.tf
+++ b/infra/terraform/cloudfront.tf
@@ -1,0 +1,58 @@
+resource "aws_cloudfront_origin_access_control" "site" {
+  name                              = "${local.name}-${var.environment}-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${local.name} ${var.environment}"
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100" # NA + EU only — cheapest, covers our audience
+  aliases             = [local.fqdn]
+
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_id                = "site"
+    origin_access_control_id = aws_cloudfront_origin_access_control.site.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "site"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    # AWS managed CachingOptimized — best defaults for static assets.
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  # Next.js static export uses extensionless URLs (e.g. /overview/index.html
+  # served at /overview/). Map any 403/404 from S3 back to /index.html so
+  # client-side routing works on direct deep-links.
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.web.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+}

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "web" {
+  zone_id         = data.aws_route53_zone.apex.zone_id
+  name            = local.fqdn
+  type            = "A"
+  allow_overwrite = true # take over the legacy OVH-era A record on first apply
+
+  alias {
+    name                   = aws_cloudfront_distribution.site.domain_name
+    zone_id                = aws_cloudfront_distribution.site.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,70 @@
+# GitHub Actions OIDC role for the deploy workflow.
+# Reuses the OIDC provider already created by the dumpus-api stack.
+
+locals {
+  github_oidc_enabled = var.github_repository != ""
+}
+
+data "aws_iam_policy_document" "github_assume" {
+  count = local.github_oidc_enabled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        for branch in var.github_deploy_branches :
+        "repo:${var.github_repository}:ref:refs/heads/${branch}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy" {
+  count              = local.github_oidc_enabled ? 1 : 0
+  name               = "${local.name}-${var.environment}-github-deploy"
+  assume_role_policy = data.aws_iam_policy_document.github_assume[0].json
+}
+
+data "aws_iam_policy_document" "github_deploy" {
+  count = local.github_oidc_enabled ? 1 : 0
+
+  statement {
+    sid     = "S3Sync"
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+      "s3:GetObject",
+    ]
+    resources = [
+      aws_s3_bucket.site.arn,
+      "${aws_s3_bucket.site.arn}/*",
+    ]
+  }
+
+  statement {
+    sid     = "CloudFrontInvalidate"
+    actions = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.site.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "github_deploy" {
+  count  = local.github_oidc_enabled ? 1 : 0
+  name   = "${local.name}-${var.environment}-github-deploy"
+  role   = aws_iam_role.github_deploy[0].id
+  policy = data.aws_iam_policy_document.github_deploy[0].json
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,15 @@
+locals {
+  name = var.name_prefix
+  fqdn = "${var.subdomain}.${var.domain_name}"
+}
+
+data "aws_route53_zone" "apex" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+# Created already by the dumpus-api stack — look it up rather than create
+# a duplicate (one IAM OIDC provider per account per issuer).
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "url" {
+  description = "Public HTTPS URL of the site"
+  value       = "https://${local.fqdn}"
+}
+
+output "site_bucket" {
+  description = "S3 bucket the deploy workflow syncs into"
+  value       = aws_s3_bucket.site.id
+}
+
+output "cloudfront_distribution_id" {
+  description = "Pass to cloudfront create-invalidation after each deploy"
+  value       = aws_cloudfront_distribution.site.id
+}
+
+output "github_deploy_role_arn" {
+  description = "Set as AWS_DEPLOY_ROLE_ARN in this repo's GH secrets"
+  value       = local.github_oidc_enabled ? aws_iam_role.github_deploy[0].arn : ""
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = var.allowed_account_ids
+
+  default_tags {
+    tags = {
+      Project     = "dumpus-app"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# CloudFront ACM certs MUST live in us-east-1 regardless of where the rest
+# of the stack runs. This alias is used only for aws_acm_certificate.web.
+provider "aws" {
+  alias               = "us_east_1"
+  region              = "us-east-1"
+  allowed_account_ids = var.allowed_account_ids
+
+  default_tags {
+    tags = {
+      Project     = "dumpus-app"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,0 +1,48 @@
+# Static-site bucket. Private; only CloudFront can read it via OAC.
+resource "aws_s3_bucket" "site" {
+  bucket = "${local.name}-site-${var.environment}"
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket                  = aws_s3_bucket.site.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Allow CloudFront to GetObject. Path-scoped to the bucket; only THIS
+# distribution (matched via aws:SourceArn) is granted.
+data "aws_iam_policy_document" "site" {
+  statement {
+    sid       = "AllowCloudFrontRead"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.site.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+  policy = data.aws_iam_policy_document.site.json
+}

--- a/infra/terraform/terraform.ci.tfvars
+++ b/infra/terraform/terraform.ci.tfvars
@@ -1,0 +1,6 @@
+region              = "eu-west-1"
+environment         = "prod"
+allowed_account_ids = ["436630934006"]
+domain_name         = "dumpus.app"
+subdomain           = "web"
+github_repository   = "dumpus-app/dumpus-app"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "region" {
+  description = "AWS region for the S3 bucket. CloudFront is global; ACM cert auto-pins to us-east-1."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "allowed_account_ids" {
+  description = "Refuse to plan/apply unless the resolved AWS credentials belong to one of these account IDs."
+  type        = list(string)
+  default     = []
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "dumpus-web"
+}
+
+variable "domain_name" {
+  description = "Apex domain (must already have a Route 53 hosted zone in this account)."
+  type        = string
+  default     = "dumpus.app"
+}
+
+variable "subdomain" {
+  description = "Hostname the site is served at. Final URL = subdomain.domain_name."
+  type        = string
+  default     = "web"
+}
+
+variable "github_repository" {
+  description = "Owner/repo allowed to assume the deploy role (e.g. dumpus-app/dumpus-app). Empty = skip."
+  type        = string
+  default     = ""
+}
+
+variable "github_deploy_branches" {
+  description = "Branches that may deploy."
+  type        = list(string)
+  default     = ["main"]
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumpus-app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "GPL-3.0",
   "packageManager": "pnpm@9.14.2",


### PR DESCRIPTION
## Summary
Moves \`web.dumpus.app\` off the OVH CapRover box onto AWS S3 + CloudFront, in the same AWS account that hosts the API. Provisioned by a small Terraform stack; deployed by GitHub Actions on push to main.

## What it provisions
- private S3 bucket (\`dumpus-web-site-prod\`) — only CloudFront can read, via Origin Access Control
- CloudFront distribution, PriceClass_100 (NA + EU)
- ACM cert in us-east-1 (CloudFront requirement)
- Route 53 A-alias for \`web.dumpus.app\` → CloudFront (allow_overwrite takes over the current OVH-era A record)
- GitHub OIDC deploy role with least-privilege (S3 sync + CloudFront invalidate only, scoped to the specific bucket and distribution)
- Reuses the existing OIDC provider already in the account (added by the dumpus-api stack)

## How deploys work
- \`infra.yml\` (manual): \`tofu plan\` / \`tofu apply\` for infra changes
- \`deploy-web.yml\` (auto on push to main): \`pnpm install && pnpm build\` → \`aws s3 sync dist/\` (long cache for hashed assets, no-cache for HTML) → CloudFront invalidate

## Required GitHub secrets
- \`BOOTSTRAP_AWS_ACCESS_KEY_ID\` / \`BOOTSTRAP_AWS_SECRET_ACCESS_KEY\` — for the infra workflow's first run
- \`AWS_DEPLOY_ROLE_ARN\` — output of \`tofu output -raw github_deploy_role_arn\` (set after first apply)
- \`CLOUDFRONT_DISTRIBUTION_ID\` — output of \`tofu output -raw cloudfront_distribution_id\` (set after first apply)

## Cost estimate
Hobby-project traffic, S3 + CloudFront only:

| | Free tier (year 1) | After year 1 |
|---|---|---|
| S3 storage | $0 | <$0.01/mo |
| CloudFront requests | 10M req/mo free | $0.0075 / 10K req |
| CloudFront egress | 1TB/mo free | $0.085/GB after 100GB always-free |
| **Total** | **\$0** | **\$1-5/mo** |

## Bootstrap order (after merge)
1. \`gh workflow run infra.yml -f action=apply\` — provisions S3 + CloudFront + cert + DNS (cert validation takes a few minutes)
2. Set \`AWS_DEPLOY_ROLE_ARN\` and \`CLOUDFRONT_DISTRIBUTION_ID\` secrets from the workflow summary
3. Push to main (or re-run \`deploy-web.yml\`) — first build + upload + invalidate
4. Verify \`https://web.dumpus.app\` loads from CloudFront (any \`x-cache: Hit/Miss from cloudfront\` header)
5. After confidence, decommission the OVH box

## Safety
- The Route 53 record for \`web\` uses \`allow_overwrite = true\` so Terraform can take over the existing OVH-era A record without conflict
- DNS propagation is fast since \`dumpus.app\` already lives on AWS nameservers