### PR TITLE
feat: point widget API at api.dumpus.app/widget

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -42,7 +42,7 @@ export const DEFAULT_PACKAGE_API_URL = "https://api.dumpus.app";
 
 export const DEFAULT_REMOTION_API_URL = "https://remotion-api.sys.dumpus.app";
 
-export const DEFAULT_WIDGET_API_URL = "https://widget.dumpus.app";
+export const DEFAULT_WIDGET_API_URL = "https://api.dumpus.app/widget";
 
 export const SQL_DEFAULT_LIMIT = 20;
 


### PR DESCRIPTION
Pairs with dumpus-api#66. Switches DEFAULT_WIDGET_API_URL from the broken OVH proxy to the new /widget route on the main API.