### PR TITLE
fix(desktop): mirror index.html for Tauri's asset resolver (AppImage crash)

### DIFF
--- a/scripts/flatten-trailing-slash.cjs
+++ b/scripts/flatten-trailing-slash.cjs
@@ -25,7 +25,9 @@ const path = require("path");
 const distDir = path.resolve(__dirname, "..", "dist");
 
 if (!fs.existsSync(distDir)) {
-  console.error(`flatten-trailing-slash: ${distDir} does not exist; did the Next build run?`);
+  console.error(
+    `flatten-trailing-slash: ${distDir} does not exist; did the Next build run?`,
+  );
   process.exit(1);
 }
 
@@ -53,4 +55,6 @@ function walk(dir) {
 
 walk(distDir);
 
-console.log(`flatten-trailing-slash: mirrored ${mirrored} index.html files for Tauri's asset resolver`);
+console.log(
+  `flatten-trailing-slash: mirrored ${mirrored} index.html files for Tauri's asset resolver`,
+);

--- a/scripts/flatten-trailing-slash.cjs
+++ b/scripts/flatten-trailing-slash.cjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+// Mirror every `dist/<path>/index.html` to a sibling `dist/<path>.html`.
+//
+// Why: next.config.mjs uses `trailingSlash: true`, so the static export
+// emits routes as `dist/onboarding/index.html`. The web build serves
+// these via S3 + CloudFront which knows to map `/foo/` to that file.
+//
+// Tauri's bundled-asset resolver does NOT do that mapping — when it's
+// asked for `onboarding`, it tries:
+//   1. `onboarding`        (literal file, doesn't exist)
+//   2. `onboarding.html`   (fallback, doesn't exist either)
+// …and gives up, leaving the WebView on a blank page where
+// `Right side of assignment cannot be destructured` blows up the JS.
+//
+// See dumpus-app/dumpus-app#366.
+//
+// We could switch to `trailingSlash: false` for desktop only, but that
+// would either fork the Next config or change the live web build's URLs.
+// Mirroring is one small build step, contained to the Tauri pipeline.
+
+const fs = require("fs");
+const path = require("path");
+
+const distDir = path.resolve(__dirname, "..", "dist");
+
+if (!fs.existsSync(distDir)) {
+  console.error(`flatten-trailing-slash: ${distDir} does not exist; did the Next build run?`);
+  process.exit(1);
+}
+
+let mirrored = 0;
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip Next's internal asset tree — those are the chunks/CSS
+      // referenced by absolute URLs from the HTML, not routes.
+      if (entry.name === "_next" || entry.name === "static") continue;
+      walk(full);
+      const indexHtml = path.join(full, "index.html");
+      if (fs.existsSync(indexHtml)) {
+        const sibling = `${full}.html`;
+        if (!fs.existsSync(sibling)) {
+          fs.copyFileSync(indexHtml, sibling);
+          mirrored += 1;
+        }
+      }
+    }
+  }
+}
+
+walk(distDir);
+
+console.log(`flatten-trailing-slash: mirrored ${mirrored} index.html files for Tauri's asset resolver`);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "build": {
-    "beforeBuildCommand": "pnpm build:desktop",
+    "beforeBuildCommand": "pnpm build:desktop && node ../scripts/flatten-trailing-slash.cjs",
     "beforeDevCommand": "pnpm dev:desktop",
     "devPath": "http://localhost:3000",
     "distDir": "../dist"


### PR DESCRIPTION
## Summary

Closes #366.

The Linux AppImage (and the desktop build in general) lands on a blank page with `Right side of assignment cannot be destructured` and neither button does anything. Multiple users have reported this.

Root cause: `next.config.mjs` uses `trailingSlash: true`, so `next build` (with `output: "export"`) emits routes as `dist/onboarding/index.html`. The web deployment knows the convention — S3 + CloudFront map `/foo/` to `dist/foo/index.html`. **Tauri's bundled-asset resolver does not.** When the WebView asks for `onboarding`, Tauri tries:

1. `dist/onboarding` (literal file — doesn't exist)
2. `dist/onboarding.html` (the fallback — also doesn't exist)

…and serves a blank page, on which the bundled JS then throws `Right side of assignment cannot be destructured` against `undefined`.

That's exactly what's in the user's screenshot in #366, and the terminal output confirms it:

```
Asset `onboarding` not found; fallback to onboarding.html
```

## Fix

A small post-build script `scripts/flatten-trailing-slash.cjs` that walks `dist/` and mirrors every `<dir>/index.html` to a sibling `<dir>.html`. Tauri's existing `.html` fallback then resolves correctly. Verified against a fake dist tree:

```
mirrored /tmp/test-dist/onboarding/access/link.html
mirrored /tmp/test-dist/onboarding.html
```

`_next/static/**` is explicitly skipped so we don't waste cycles on the asset tree.

The script runs as part of `beforeBuildCommand` in `tauri.conf.json`, so it only fires on the Tauri pipeline. The web build is untouched (it serves from S3 where the directory layout is the source of truth and never sees the `.html` siblings).

## Why not just flip `trailingSlash: false`?

Would either fork the Next config (extra complexity) or change the live web URLs (which CloudFront and any external links assume). One small build step is contained to the desktop pipeline and is reversible.

## Test plan

- [ ] Merge → trigger the desktop build workflow.
- [ ] Run the resulting AppImage on Linux. The error screen should be gone, "Get my package" / "Try the demo" buttons should navigate normally.
- [ ] Web build (`pnpm build`) unchanged — `dist/onboarding/index.html` still present, `dist/onboarding.html` not generated.