### PR TITLE
feat(loading): handle MISSING_USER_DATA error from API

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -157,6 +157,7 @@
       "invalidLink": "Link invalid.",
       "unknownError": "An unknown error occurred.",
       "expiredLink": "Link expired.",
+      "missingUserData": "Your Discord export is missing your User data. When requesting your data again, make sure the \"User data\" option is ticked.",
       "comeBackLater": "You can close and come back later."
     }
   },

--- a/src/app/onboarding/loading/page.tsx
+++ b/src/app/onboarding/loading/page.tsx
@@ -36,6 +36,7 @@ export default function Page() {
             INVALID_LINK: t("onboarding.loading.invalidLink"),
             UNKNOWN_ERROR: t("onboarding.loading.unknownError"),
             EXPIRED_LINK: t("onboarding.loading.expiredLink"),
+            MISSING_USER_DATA: t("onboarding.loading.missingUserData"),
           }[error]
         }
         url="/onboarding/access/link/"

--- a/src/types/package-api.ts
+++ b/src/types/package-api.ts
@@ -26,7 +26,9 @@ export type PackageAPIStatusResponse = Prettify<
           | "UNKNOWN_PACKAGE_ID"
           | "UNKNOWN_ERROR"
           | "UNAUTHORIZED"
-          | "EXPIRED_LINK";
+          | "EXPIRED_LINK"
+          | "INVALID_LINK"
+          | "MISSING_USER_DATA";
       }
   ) &
     (


### PR DESCRIPTION
## Summary

Pairs with dumpus-app/dumpus-api#80, which adds a new \`MISSING_USER_DATA\` error code on the API. The worker raises that code when a Discord export package ships without \`user.json\` — which happens when the user un-ticks the **User data** checkbox in Discord's data-request form. Two production failures today (\`d92006c186e5d2bfaff622e20080fb8b\` and \`cbc913a1af14c87789ebd492733fefcd\`) were caused by exactly this.

## Changes

- **Type**: widened \`PackageAPIStatusResponse.errorMessageCode\` to include \`MISSING_USER_DATA\` and \`INVALID_LINK\` (the latter the API has been able to return since dumpus-app/dumpus-api#79, but the type hadn't caught up).
- **Loading page**: added the new code to the error → translation map in \`src/app/onboarding/loading/page.tsx\`.
- **en.json**: added \`onboarding.loading.missingUserData\`:
  > Your Discord export is missing your User data. When requesting your data again, make sure the \"User data\" option is ticked.
- Other locales will fill in via Crowdin.

## Test plan

- [ ] Merge after dumpus-app/dumpus-api#80 deploys.
- [ ] Submit a package without \`user.json\` (or wait for one of the affected users to retry). Loading page should show the new copy instead of the generic \"unknown error\".
- [ ] Existing error paths (\`EXPIRED_LINK\`, \`UNKNOWN_PACKAGE_ID\`, etc.) still render as before.