### PR TITLE
fix(desktop): invoke flatten-dist via pnpm so cwd doesn't matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "cross-env-shell NEXT_PUBLIC_DEPLOY_ENV=web \"pnpm script:list-locales && cross-env next lint\"",
     "prepare": "pnpm script:list-locales",
     "script:build-android": "cross-env-shell NODE_ENV=production \"cap sync\" && node ./scripts/build-android.cjs",
+    "script:flatten-dist": "node ./scripts/flatten-trailing-slash.cjs",
     "script:list-locales": "node ./scripts/list-locales.cjs",
     "start": "serve dist",
     "tauri:icon": "tauri icon ./ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60@3x~car.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "build": {
-    "beforeBuildCommand": "pnpm build:desktop && node ../scripts/flatten-trailing-slash.cjs",
+    "beforeBuildCommand": "pnpm build:desktop && pnpm script:flatten-dist",
     "beforeDevCommand": "pnpm dev:desktop",
     "devPath": "http://localhost:3000",
     "distDir": "../dist"


### PR DESCRIPTION
## Summary

Hotfix for the v1.0.8 desktop build failure: https://github.com/dumpus-app/dumpus-app/actions/runs/25256499135

## What broke

In #408 I set:
\`\`\`json
\"beforeBuildCommand\": \"pnpm build:desktop && node ../scripts/flatten-trailing-slash.cjs\"
\`\`\`

I assumed Tauri's \`beforeBuildCommand\` cwd was \`src-tauri/\` (so \`../scripts/\` would resolve to repo root). It's actually the repo root itself, so \`../scripts/\` resolved one level **above** the repo and the file was missing:

\`\`\`
Error: Cannot find module '/Users/runner/work/dumpus-app/scripts/flatten-trailing-slash.cjs'
Error beforeBuildCommand `pnpm build:desktop && node ../scripts/flatten-trailing-slash.cjs` failed with exit code 1
\`\`\`

GitHub Actions checks out at \`/Users/runner/work/<repo>/<repo>/\`, so \`../\` from there is the workspace parent — empty.

## Fix

Wrap the script invocation in a pnpm script:

\`\`\`json
\"script:flatten-dist\": \"node ./scripts/flatten-trailing-slash.cjs\"
\`\`\`

…and call it via \`pnpm script:flatten-dist\` in \`beforeBuildCommand\`. \`pnpm\` always resolves scripts from the package root regardless of cwd, so the cwd ambiguity goes away. Also makes the script callable standalone for local testing (\`pnpm script:flatten-dist\`).

## Aftermath for v1.0.8

The v1.0.8 desktop build artifacts (AppImage / dmg / msi) won't be produced from the failed run. To recover, after this merges:

1. Delete the v1.0.8 GitHub Release (keep the tag)
2. Re-create it: \`gh release create v1.0.8 --generate-notes\` — that re-fires the build/deploy workflows against current main (which now includes this fix)

Or roll the fix into v1.0.9 if you'd rather not touch the v1.0.8 release.

## Test plan

- [ ] Merge.
- [ ] Re-trigger the desktop build (re-create v1.0.8 release, or trigger via workflow_dispatch). All three platforms (ubuntu, macos, windows) should pass the beforeBuildCommand step.