### PR TITLE
perf(stores): cache activity-table extremity dates per db instance

### DIFF
--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -63,9 +63,7 @@ export const createDatabaseSlice: CreateSlice<DatabaseSlice> = (set, get) => ({
     // backed by a per-db cache instead of a fresh full-table scan each call.
     const ext = db ? readExtremities(db) : null;
     const rawExtremityDates: [string, string] | undefined =
-      ext && ext[0] !== null && ext[1] !== null
-        ? [ext[0], ext[1]]
-        : undefined;
+      ext && ext[0] !== null && ext[1] !== null ? [ext[0], ext[1]] : undefined;
 
     const startDateLimit = new Date(rawExtremityDates?.[0] || "2015-05-13"); // Discord creation
     const endDate = rawExtremityDates

--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -25,17 +25,47 @@ type Actions = {
 
 export type DatabaseSlice = State & Actions;
 
+// Memoize the MIN(day)/MAX(day) full-table scan per database instance.
+// Without this cache, every render of every data hook (and there are ~10 of
+// them across the screens) re-runs that scan against the full activity table,
+// which can have 100k+ rows. WeakMap means stale entries get GC'd when the
+// db reference itself gets replaced (e.g. on package switch).
+const extremitiesCache = new WeakMap<
+  Database,
+  [string | null, string | null]
+>();
+
+function readExtremities(db: Database): [string | null, string | null] {
+  const cached = extremitiesCache.get(db);
+  if (cached) return cached;
+
+  const queryData = db.exec(
+    "SELECT MIN(day) AS start, MAX(day) AS end FROM activity",
+  );
+  const row = queryData?.[0]?.values[0] as
+    | [string | null, string | null]
+    | undefined;
+  const computed: [string | null, string | null] = [
+    row?.[0] ?? null,
+    row?.[1] ?? null,
+  ];
+  extremitiesCache.set(db, computed);
+  return computed;
+}
+
 export const createDatabaseSlice: CreateSlice<DatabaseSlice> = (set, get) => ({
   db: null,
   setDB: (v) => set((state) => ({ database: { ...state.database, db: v } })),
   getNextID: (id) => (id ? `${parseInt(id) + 1}` : "0"),
   getTimeRangeDates: ({ timeRange, db }) => {
-    const queryData = db?.exec(
-      "SELECT MIN(day) AS start, MAX(day) AS end FROM activity",
-    );
-    const rawExtremityDates = queryData?.[0].values[0] as
-      | [string, string]
-      | undefined;
+    // Original code accepted [string, string] | undefined and fell back to
+    // (Discord epoch, now) when missing. Preserve that exact behaviour, just
+    // backed by a per-db cache instead of a fresh full-table scan each call.
+    const ext = db ? readExtremities(db) : null;
+    const rawExtremityDates: [string, string] | undefined =
+      ext && ext[0] !== null && ext[1] !== null
+        ? [ext[0], ext[1]]
+        : undefined;
 
     const startDateLimit = new Date(rawExtremityDates?.[0] || "2015-05-13"); // Discord creation
     const endDate = rawExtremityDates


### PR DESCRIPTION
## Summary

Likely root cause of the 1-2s navigation lag the user has been reporting on web.dumpus.app.

\`getTimeRangeDates()\` in \`src/stores/database.ts\` runs

\`\`\`sql
SELECT MIN(day) AS start, MAX(day) AS end FROM activity
\`\`\`

…directly against \`db.exec(...)\`. That's a **full table scan** on a table that can have 100k+ rows, and it **bypasses the queriesCache in useSQL** because it goes through \`db.exec\` directly rather than the tagged-template wrapper.

Worse: \`getTimeRangeDates()\` is called inline from \`useDataSources()\` (\`src/hooks/data/_shared.ts\`), which is the entry point of every per-screen data hook — \`use-top-dms-data\`, \`use-top-channels-data\`, \`use-guild-data\`, \`use-channel-data\`, \`use-dm-data\`, \`use-sending-times-data\`, \`use-usage-stats-data\`, etc. Counting:

- A typical screen instantiates 3-5 of these hooks
- Each render re-runs \`useDataSources\` → \`getTimeRangeDates\` → MIN/MAX scan
- React rerenders during navigation easily multiply that by 3-5x

Result: 9-25 full activity-table scans per click on a heavy package. At ~30-100 ms per scan in sql.js for 100k rows, that's **270 ms - 2.5 s** of pure SQL overhead per nav.

## Fix

Cache the \`[MIN(day), MAX(day)]\` tuple in a \`WeakMap<Database, ...>\` and read from it on subsequent calls. The data is immutable for a given package, so a single scan per db lifetime is enough.

\`WeakMap\` keyed on the db reference means:
- Hit-rate is 100% within a session.
- When the user switches packages, the old db reference goes out of scope and the WeakMap entry GCs automatically — no manual invalidation.

Behaviour-preserving: the existing \"fall back to Discord epoch / now when extremity is missing\" path is kept intact (matches the original \`as [string, string] | undefined\` cast that was already lenient about nulls).

## Verification

- Local \`pnpm build\` passes.
- \`tsc --noEmit\` clean.
- Tested manually by adding console.log to readExtremities — fires once per db, not per render.

## Related

This pairs with #77 in the API repo (which adds SQLite indexes), but those only help **newly** processed packages. Existing user packages on web.dumpus.app would still be unindexed, so this caching fix is the right place to fight the lag for current data.

## Test plan

- [ ] Merge.
- [ ] Open web.dumpus.app, load a package, click between screens. Should feel snappier — the per-nav SQL overhead drops by ~10-20×.
- [ ] Switch to a different package: verify the new package's dates are correct (cache should not leak across db references — WeakMap handles this).