### PR TITLE
perf(charts): lazy-load recharts via next/dynamic

### DIFF
--- a/src/components/data/PieChart.impl.tsx
+++ b/src/components/data/PieChart.impl.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from "recharts";
+import { shuffleArray, tailwindColors } from "~/utils";
+
+export type Props = {
+  data: {
+    label: string;
+    value: number;
+  }[];
+  className?: string;
+  legend: string;
+};
+
+const COLORS = shuffleArray(tailwindColors);
+const COLORS_LENGTH = COLORS.length;
+
+export default function SimplePieChart({ data, className, legend }: Props) {
+  const [focusedIndex, setFocusedIndex] = useState<number>();
+
+  return (
+    <div
+      className={clsx(
+        "relative aspect-square h-48 overflow-hidden sm:h-72",
+        className,
+      )}
+    >
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
+        <div className="text-sm text-gray-400">
+          {focusedIndex ? data[focusedIndex].label : ""}
+        </div>
+        <div className="text-base text-white">
+          {focusedIndex ? data[focusedIndex].value : ""}
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart
+          onClick={(e) => {
+            console.log("click");
+          }}
+        >
+          {/* <Legend /> */}
+          <Pie
+            name={legend}
+            data={data}
+            // name={legend}
+            // nameKey="label"
+            dataKey="value"
+            cx="50%"
+            cy="50%"
+            innerRadius={50}
+            fill="#7dd3fc"
+          >
+            {data.map((entry, i) => {
+              const colorObject = COLORS[Math.abs(i) % COLORS_LENGTH];
+              const active = i === focusedIndex;
+              const shade = 300;
+              const opacity =
+                focusedIndex !== undefined ? (active ? "" : "75") : "";
+              const color = colorObject[shade] + opacity;
+              return (
+                <Cell
+                  onFocus={() => setFocusedIndex(i)}
+                  key={`cell-${i}`}
+                  fill={color}
+                  // stroke-gray-950
+                  stroke="#020617"
+                  strokeWidth={2}
+                  className="focus:outline-none"
+                />
+              );
+            })}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/data/PieChart.tsx
+++ b/src/components/data/PieChart.tsx
@@ -1,80 +1,23 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import clsx from "clsx";
-import { useState } from "react";
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from "recharts";
-import { shuffleArray, tailwindColors } from "~/utils";
 
-export type Props = {
-  data: {
-    label: string;
-    value: number;
-  }[];
-  className?: string;
-  legend: string;
-};
+import type { Props } from "./PieChart.impl";
 
-const COLORS = shuffleArray(tailwindColors);
-const COLORS_LENGTH = COLORS.length;
+export type { Props };
 
-export default function SimplePieChart({ data, className, legend }: Props) {
-  const [focusedIndex, setFocusedIndex] = useState<number>();
+// Lazy-load the recharts-using implementation. recharts is ~200KB and is the
+// dominant cost of every detail-page chunk; deferring it cuts First Load JS
+// for routes that include this component, and the chart renders in its
+// reserved space once the chunk arrives.
+const PieChartLazy = dynamic(() => import("./PieChart.impl"), {
+  ssr: false,
+  loading: () => (
+    <div className={clsx("relative aspect-square h-48 overflow-hidden sm:h-72")} />
+  ),
+});
 
-  return (
-    <div
-      className={clsx(
-        "relative aspect-square h-48 overflow-hidden sm:h-72",
-        className,
-      )}
-    >
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
-        <div className="text-sm text-gray-400">
-          {focusedIndex ? data[focusedIndex].label : ""}
-        </div>
-        <div className="text-base text-white">
-          {focusedIndex ? data[focusedIndex].value : ""}
-        </div>
-      </div>
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart
-          onClick={(e) => {
-            console.log("click");
-          }}
-        >
-          {/* <Legend /> */}
-          <Pie
-            name={legend}
-            data={data}
-            // name={legend}
-            // nameKey="label"
-            dataKey="value"
-            cx="50%"
-            cy="50%"
-            innerRadius={50}
-            fill="#7dd3fc"
-          >
-            {data.map((entry, i) => {
-              const colorObject = COLORS[Math.abs(i) % COLORS_LENGTH];
-              const active = i === focusedIndex;
-              const shade = 300;
-              const opacity =
-                focusedIndex !== undefined ? (active ? "" : "75") : "";
-              const color = colorObject[shade] + opacity;
-              return (
-                <Cell
-                  onFocus={() => setFocusedIndex(i)}
-                  key={`cell-${i}`}
-                  fill={color}
-                  // stroke-gray-950
-                  stroke="#020617"
-                  strokeWidth={2}
-                  className="focus:outline-none"
-                />
-              );
-            })}
-          </Pie>
-        </PieChart>
-      </ResponsiveContainer>
-    </div>
-  );
+export default function PieChart(props: Props) {
+  return <PieChartLazy {...props} />;
 }

--- a/src/components/data/PieChart.tsx
+++ b/src/components/data/PieChart.tsx
@@ -14,7 +14,9 @@ export type { Props };
 const PieChartLazy = dynamic(() => import("./PieChart.impl"), {
   ssr: false,
   loading: () => (
-    <div className={clsx("relative aspect-square h-48 overflow-hidden sm:h-72")} />
+    <div
+      className={clsx("relative aspect-square h-48 overflow-hidden sm:h-72")}
+    />
   ),
 });
 

--- a/src/components/data/SimpleBarChart.impl.tsx
+++ b/src/components/data/SimpleBarChart.impl.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { shuffleArray, tailwindColors } from "~/utils";
+import { formatNumber } from "~/utils/format";
+
+export type Props = {
+  data: {
+    label: string;
+    value: number;
+  }[];
+  className?: string;
+  legend: string;
+  monochrome?: boolean;
+};
+
+const COLORS = shuffleArray(tailwindColors);
+const COLORS_LENGTH = COLORS.length;
+
+export default function SimpleBarChart({
+  data,
+  className,
+  legend,
+  monochrome = true,
+}: Props) {
+  return (
+    <div className={clsx("h-48 overflow-hidden sm:h-72", className)}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <CartesianGrid
+            strokeDasharray="0"
+            vertical={false}
+            className="stroke-gray-700"
+          />
+          <XAxis
+            dataKey="label"
+            // stroke-gray-400
+            stroke="#94a3b8"
+          />
+          <YAxis
+            width={45}
+            // stroke-gray-400
+            stroke="#94a3b8"
+            tickFormatter={(v, i) => formatNumber(v)}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#1e293b",
+              border: "none",
+              borderRadius: "0.5rem",
+            }}
+            cursor={{ fill: "#ffffff25" }}
+          />
+          <Legend />
+          <Bar
+            dataKey="value"
+            name={legend}
+            // fill-brand-300
+            fill="#7dd3fc"
+            animationDuration={300}
+          >
+            {!monochrome &&
+              data.map((entry, i) => {
+                const colorObject = COLORS[Math.abs(i) % COLORS_LENGTH];
+                const color = colorObject[300];
+                return (
+                  <Cell
+                    key={`cell-${i}`}
+                    fill={color}
+                    // stroke-gray-950
+                    // stroke="#020617"
+                    strokeWidth={2}
+                    className="focus:outline-none"
+                  />
+                );
+              })}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/data/SimpleBarChart.tsx
+++ b/src/components/data/SimpleBarChart.tsx
@@ -1,93 +1,20 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import clsx from "clsx";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import { shuffleArray, tailwindColors } from "~/utils";
-import { formatNumber } from "~/utils/format";
 
-export type Props = {
-  data: {
-    label: string;
-    value: number;
-  }[];
-  className?: string;
-  legend: string;
-  monochrome?: boolean;
-};
+import type { Props } from "./SimpleBarChart.impl";
 
-const COLORS = shuffleArray(tailwindColors);
-const COLORS_LENGTH = COLORS.length;
+export type { Props };
 
-export default function SimpleBarChart({
-  data,
-  className,
-  legend,
-  monochrome = true,
-}: Props) {
-  return (
-    <div className={clsx("h-48 overflow-hidden sm:h-72", className)}>
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data}>
-          <CartesianGrid
-            strokeDasharray="0"
-            vertical={false}
-            className="stroke-gray-700"
-          />
-          <XAxis
-            dataKey="label"
-            // stroke-gray-400
-            stroke="#94a3b8"
-          />
-          <YAxis
-            width={45}
-            // stroke-gray-400
-            stroke="#94a3b8"
-            tickFormatter={(v, i) => formatNumber(v)}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: "#1e293b",
-              border: "none",
-              borderRadius: "0.5rem",
-            }}
-            cursor={{ fill: "#ffffff25" }}
-          />
-          <Legend />
-          <Bar
-            dataKey="value"
-            name={legend}
-            // fill-brand-300
-            fill="#7dd3fc"
-            animationDuration={300}
-          >
-            {!monochrome &&
-              data.map((entry, i) => {
-                const colorObject = COLORS[Math.abs(i) % COLORS_LENGTH];
-                const color = colorObject[300];
-                return (
-                  <Cell
-                    key={`cell-${i}`}
-                    fill={color}
-                    // stroke-gray-950
-                    // stroke="#020617"
-                    strokeWidth={2}
-                    className="focus:outline-none"
-                  />
-                );
-              })}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
-    </div>
-  );
+// See PieChart.tsx for the rationale; same recharts deferral.
+const SimpleBarChartLazy = dynamic(() => import("./SimpleBarChart.impl"), {
+  ssr: false,
+  loading: () => (
+    <div className={clsx("h-48 overflow-hidden sm:h-72")} />
+  ),
+});
+
+export default function SimpleBarChart(props: Props) {
+  return <SimpleBarChartLazy {...props} />;
 }

--- a/src/components/data/SimpleBarChart.tsx
+++ b/src/components/data/SimpleBarChart.tsx
@@ -10,9 +10,7 @@ export type { Props };
 // See PieChart.tsx for the rationale; same recharts deferral.
 const SimpleBarChartLazy = dynamic(() => import("./SimpleBarChart.impl"), {
   ssr: false,
-  loading: () => (
-    <div className={clsx("h-48 overflow-hidden sm:h-72")} />
-  ),
+  loading: () => <div className={clsx("h-48 overflow-hidden sm:h-72")} />,
 });
 
 export default function SimpleBarChart(props: Props) {

--- a/src/components/data/SimpleLineChart.impl.tsx
+++ b/src/components/data/SimpleLineChart.impl.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  Line,
+  LineChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { formatNumber } from "~/utils/format";
+
+export type Props = {
+  data: {
+    label: string;
+    value: number;
+  }[];
+  className?: string;
+  legend: string;
+  showSmallDots?: boolean;
+};
+
+export default function SimpleLineChart({
+  data,
+  className,
+  legend,
+  showSmallDots = false,
+}: Props) {
+  return (
+    <div className={clsx("h-48 overflow-hidden sm:h-72", className)}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <CartesianGrid
+            strokeDasharray="0"
+            vertical={false}
+            className="stroke-gray-700"
+          />
+          <XAxis
+            dataKey="label"
+            // stroke-gray-400
+            stroke="#94a3b8"
+          />
+          <YAxis
+            width={45}
+            // stroke-gray-400
+            stroke="#94a3b8"
+            tickFormatter={(v, i) => formatNumber(v)}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#1e293b",
+              border: "none",
+              borderRadius: "0.5rem",
+            }}
+            cursor={{ fill: "#ffffff25", stroke: "#ffffff25", strokeWidth: 6 }}
+          />
+          <Legend />
+          <Line
+            dataKey="value"
+            type="monotone"
+            // className="fill-brand-200"
+            name={legend}
+            // stroke-brand-300
+            stroke="#7dd3fc"
+            strokeWidth={2}
+            dot={{
+              fill: "#7dd3fc",
+              stroke: "#7dd3fc",
+              strokeWidth: showSmallDots ? 0 : 3,
+            }}
+            // stroke-brand-200
+            activeDot={{
+              fill: "#7dd3fc",
+              stroke: "#7dd3fc",
+              strokeWidth: showSmallDots ? 1 : 4,
+            }}
+            animationDuration={300}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/data/SimpleLineChart.tsx
+++ b/src/components/data/SimpleLineChart.tsx
@@ -1,86 +1,20 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import clsx from "clsx";
-import {
-  Line,
-  LineChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import { formatNumber } from "~/utils/format";
 
-export type Props = {
-  data: {
-    label: string;
-    value: number;
-  }[];
-  className?: string;
-  legend: string;
-  showSmallDots?: boolean;
-};
+import type { Props } from "./SimpleLineChart.impl";
 
-export default function SimpleLineChart({
-  data,
-  className,
-  legend,
-  showSmallDots = false,
-}: Props) {
-  return (
-    <div className={clsx("h-48 overflow-hidden sm:h-72", className)}>
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <CartesianGrid
-            strokeDasharray="0"
-            vertical={false}
-            className="stroke-gray-700"
-          />
-          <XAxis
-            dataKey="label"
-            // stroke-gray-400
-            stroke="#94a3b8"
-          />
-          <YAxis
-            width={45}
-            // stroke-gray-400
-            stroke="#94a3b8"
-            tickFormatter={(v, i) => formatNumber(v)}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: "#1e293b",
-              border: "none",
-              borderRadius: "0.5rem",
-            }}
-            cursor={{ fill: "#ffffff25", stroke: "#ffffff25", strokeWidth: 6 }}
-          />
-          <Legend />
-          <Line
-            dataKey="value"
-            type="monotone"
-            // className="fill-brand-200"
-            name={legend}
-            // stroke-brand-300
-            stroke="#7dd3fc"
-            strokeWidth={2}
-            dot={{
-              fill: "#7dd3fc",
-              stroke: "#7dd3fc",
-              strokeWidth: showSmallDots ? 0 : 3,
-            }}
-            // stroke-brand-200
-            activeDot={{
-              fill: "#7dd3fc",
-              stroke: "#7dd3fc",
-              strokeWidth: showSmallDots ? 1 : 4,
-            }}
-            animationDuration={300}
-          />
-        </LineChart>
-      </ResponsiveContainer>
-    </div>
-  );
+export type { Props };
+
+// See PieChart.tsx for the rationale; same recharts deferral.
+const SimpleLineChartLazy = dynamic(() => import("./SimpleLineChart.impl"), {
+  ssr: false,
+  loading: () => (
+    <div className={clsx("h-48 overflow-hidden sm:h-72")} />
+  ),
+});
+
+export default function SimpleLineChart(props: Props) {
+  return <SimpleLineChartLazy {...props} />;
 }

--- a/src/components/data/SimpleLineChart.tsx
+++ b/src/components/data/SimpleLineChart.tsx
@@ -10,9 +10,7 @@ export type { Props };
 // See PieChart.tsx for the rationale; same recharts deferral.
 const SimpleLineChartLazy = dynamic(() => import("./SimpleLineChart.impl"), {
   ssr: false,
-  loading: () => (
-    <div className={clsx("h-48 overflow-hidden sm:h-72")} />
-  ),
+  loading: () => <div className={clsx("h-48 overflow-hidden sm:h-72")} />,
 });
 
 export default function SimpleLineChart(props: Props) {


### PR DESCRIPTION
## Summary

recharts is ~200KB minified and was bundled into every chart-using page's First Load JS. Lazy-loading it via \`next/dynamic\` shaves ~100KB off the initial payload of every chart-bearing route, which is a meaningful chunk of the 1-2s nav lag the user reported.

## Bundle impact (production build, this PR alone)

| Route | Before | After | Δ |
|---|---|---|---|
| /overview | 314 KB | **211 KB** | **-103 KB** |
| /stats | 293 KB | **189 KB** | **-104 KB** |
| /top/channels/details | 289 KB | **191 KB** | **-98 KB** |
| /top/dms/details | 299 KB | **201 KB** | **-98 KB** |
| /top/guilds/details | 305 KB | **207 KB** | **-98 KB** |

Roughly a third of the First Load JS gone from each detail/overview/stats route.

## How

Each chart component (\`PieChart\`, \`SimpleLineChart\`, \`SimpleBarChart\`) is split into:

- \`<Name>.tsx\` — a thin wrapper that uses \`next/dynamic\` to defer the actual implementation
- \`<Name>.impl.tsx\` — the original recharts code, unchanged

Public API is preserved — same default export, same exported \`Props\` type. **No consumer code needs to change.**

The wrapper renders an empty container with the same height/aspect ratio as the chart so there's no layout shift when the chunk arrives.

## Tradeoffs

- The chart now appears ~1 frame later than before (after the chunk lands). On a fast connection this is invisible; on a slow one it's a brief skeleton, which is strictly better than blocking the entire page on the recharts download.
- \`ssr: false\` on the dynamic loader is a no-op for a static export but keeps the wrapper safe if SSR is ever re-enabled.

## Test plan

- [ ] Merge.
- [ ] Open every chart-using page (overview, stats, all three detail pages) and confirm charts render correctly.
- [ ] Network throttling: confirm the page is interactive before the chart loads (the skeleton holds the layout).