### PR TITLE
perf(share): defer html2canvas + react-dom/server until share is clicked

### DIFF
--- a/src/hooks/use-generate-img.ts
+++ b/src/hooks/use-generate-img.ts
@@ -1,8 +1,6 @@
 "use client";
 
-import html2canvas from "html2canvas";
 import { useCallback } from "react";
-import { renderToString } from "react-dom/server";
 import StaticShareImage, {
   type Props as StaticShareImageProps,
 } from "~/components/StaticShareImage";
@@ -12,6 +10,14 @@ const height = 775;
 
 export default function useGenerateImg() {
   const generate = useCallback(async function (props: StaticShareImageProps) {
+    // Lazy-load html2canvas (~150KB) and react-dom/server (~40KB) only when
+    // the user actually triggers a share. Both are heavy, used here once,
+    // and not needed for the rest of the app to function.
+    const [{ default: html2canvas }, { renderToString }] = await Promise.all([
+      import("html2canvas"),
+      import("react-dom/server"),
+    ]);
+
     // Create element with Static Share Card
     const element = document.createElement("div");
     element.innerHTML = renderToString(StaticShareImage(props));


### PR DESCRIPTION
## Summary

Smaller-than-headline win, but still real. SharePopup is mounted in the global \`(app)\` layout, so \`html2canvas\` was in every authenticated route's dependency graph. Webpack was already code-splitting it into a ~200KB chunk (\`c132bf7d.*.js\`) but that chunk was being preloaded with each route. **Users who never tap the share button still paid for the download.**

## Change

Replace the static imports of \`html2canvas\` and \`react-dom/server\` in \`useGenerateImg\` with \`await import()\` inside the \`generate()\` callback:

\`\`\`ts
const [{ default: html2canvas }, { renderToString }] = await Promise.all([
  import(\"html2canvas\"),
  import(\"react-dom/server\"),
]);
\`\`\`

The chunk now loads only when \`generate()\` is actually invoked (i.e. when the user opens the share sheet).

## Impact

- **First share click**: one-time ~100-300ms fetch latency (cached after).
- **Every other interaction**: ~200KB less downloaded across the session.
- **First Load JS metric**: unchanged (Webpack was already splitting the chunk; this just changes when it's fetched).

The semantic improvement is what matters here — code that may never be used shouldn't be downloaded eagerly.

## Test plan

- [ ] Open a non-demo package, navigate to overview.
- [ ] Open DevTools → Network. Filter by JS.
- [ ] Verify the html2canvas chunk does NOT appear in the initial page load.
- [ ] Click share. The chunk should load on click. The share image should generate as before.