### PR TITLE
fix(security): add rel=noopener noreferrer to markdown target=_blank links

### DIFF
--- a/src/components/RenderMarkdown.tsx
+++ b/src/components/RenderMarkdown.tsx
@@ -13,7 +13,12 @@ export default function RenderMarkdown({
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
-        a: (props: any) => <a {...props} target="_blank" />,
+        // rel guards against reverse tabnabbing — without it, the linked
+        // page can navigate `window.opener` of the original tab. noreferrer
+        // also strips the Referer header for privacy.
+        a: (props: any) => (
+          <a {...props} target="_blank" rel="noopener noreferrer" />
+        ),
         ...(noClosingTag
           ? {
               p: Fragment,


### PR DESCRIPTION
## Summary

\`RenderMarkdown\` opens external links in a new tab via \`target=\"_blank\"\` but doesn't set \`rel\`. That's a classic **reverse tabnabbing** vector: without \`rel=\"noopener\"\`, the linked page can read \`window.opener\` of the original tab and call \`window.opener.location = \"https://phish.example/\"\` to silently redirect the user away from web.dumpus.app to a lookalike.

Modern Chromium / Firefox default to noopener semantics for \`target=_blank\` since ~2020, but:
- The Capacitor WebView and other embedded contexts may not.
- Defending in code is one line and removes the dependency on browser default behavior.

\`rel=\"noreferrer\"\` is paired with it as the standard fix — it also strips the \`Referer\` header so the destination doesn't see what page on dumpus the user clicked from.

## Diff

\`\`\`diff
-        a: (props: any) => <a {...props} target=\"_blank\" />,
+        a: (props: any) => (
+          <a {...props} target=\"_blank\" rel=\"noopener noreferrer\" />
+        ),
\`\`\`

## Test plan

- [ ] Render any markdown content with an external link (credits page, premium description).
- [ ] Inspect element on the rendered link — \`rel=\"noopener noreferrer\"\` should be present.
- [ ] Click the link — opens in a new tab as before.