### PR TITLE
a11y(share): give share-image avatars meaningful alt text

### DIFF
--- a/src/components/StaticShareImage.tsx
+++ b/src/components/StaticShareImage.tsx
@@ -74,7 +74,7 @@ function TopList({
               {/* eslint-disable-next-line */}
               <img
                 src={url}
-                alt=""
+                alt={name}
                 className="rounded-full object-cover object-center"
                 width={48}
                 height={48}
@@ -121,7 +121,7 @@ export default function StaticShareImage({
             {/* eslint-disable-next-line */}
             <img
               src={user.avatarURL}
-              alt=""
+              alt={user.displayName}
               className="rounded-full object-cover object-center"
               width={128}
               height={128}
@@ -224,7 +224,7 @@ export default function StaticShareImage({
             {/* eslint-disable-next-line */}
             <img
               src="/assets/logo.png"
-              alt=""
+              alt="Dumpus"
               className="rounded-full object-cover object-center"
               width={64}
               height={64}


### PR DESCRIPTION
## Summary

The three \`<img>\` tags in \`StaticShareImage\` were rendered with \`alt=\"\"\`, which signals to screen readers that the image is decorative. They're not — they're user avatars and the Dumpus logo. The audit (separate issue with the full code-quality findings) flagged this.

## Changes

- Top-DM / top-guild rows: \`alt={name}\` so the listed user/guild name is announced.
- Main user avatar: \`alt={user.displayName}\`.
- Dumpus logo: \`alt=\"Dumpus\"\`.

No layout / styling change. Affects the rendered share image, screen-reader output, and SEO metadata of any embedded preview.