### PR TITLE
chore(release): 1.0.10 (re-issue)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.dumpus.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 28
-        versionName "1.0.9"
+        versionCode 29
+        versionName "1.0.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQ53Y973KM;
 				INFOPLIST_FILE = App/Info.plist;
@@ -376,13 +376,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQ53Y973KM;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = app.dumpus.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumpus-app",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "license": "GPL-3.0",
   "packageManager": "pnpm@9.14.2",


### PR DESCRIPTION
The original v1.0.10 GitHub Release was cut while \`main\` was still at versionCode 28 / version 1.0.9 — the release-bump commit had landed on the \`a11y/share-image-alts\` branch instead of \`main\`. As a result the published artifacts (AAB, dmg, msi, etc.) all carry version 1.0.9 and Play rejects them as duplicates of the actual v1.0.9.

This PR cherry-picks the release commit onto a clean branch from current main so the bumps reach main. After merge:

1. Delete the broken v1.0.10 GitHub Release + tag
2. Re-create v1.0.10 from main HEAD — workflows re-fire and build correct artifacts at versionCode 29 / version 1.0.10

versionCode 28 → 29; versionName 1.0.9 → 1.0.10; iOS CURRENT_PROJECT_VERSION 28 → 29; iOS MARKETING_VERSION 1.0.9 → 1.0.10.