### PR TITLE
feat(loading): handle MISSING_ACTIVITY_DATA error from API

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -158,6 +158,7 @@
       "unknownError": "An unknown error occurred.",
       "expiredLink": "Link expired.",
       "missingUserData": "Your Discord export is missing your User data. When requesting your data again, make sure the \"User data\" option is ticked.",
+      "missingActivityData": "Your Discord export is missing your activity history. When requesting your data again, make sure the \"Activity history\" option is ticked.",
       "comeBackLater": "You can close and come back later."
     }
   },

--- a/src/app/onboarding/loading/page.tsx
+++ b/src/app/onboarding/loading/page.tsx
@@ -37,6 +37,7 @@ export default function Page() {
             UNKNOWN_ERROR: t("onboarding.loading.unknownError"),
             EXPIRED_LINK: t("onboarding.loading.expiredLink"),
             MISSING_USER_DATA: t("onboarding.loading.missingUserData"),
+            MISSING_ACTIVITY_DATA: t("onboarding.loading.missingActivityData"),
           }[error]
         }
         url="/onboarding/access/link/"

--- a/src/types/package-api.ts
+++ b/src/types/package-api.ts
@@ -28,7 +28,8 @@ export type PackageAPIStatusResponse = Prettify<
           | "UNAUTHORIZED"
           | "EXPIRED_LINK"
           | "INVALID_LINK"
-          | "MISSING_USER_DATA";
+          | "MISSING_USER_DATA"
+          | "MISSING_ACTIVITY_DATA";
       }
   ) &
     (


### PR DESCRIPTION
Pairs with dumpus-app/dumpus-api#81 — surfaces the new \`MISSING_ACTIVITY_DATA\` code (Discord export with the \"Activity history\" checkbox un-ticked) instead of letting it fall through to the generic UNKNOWN_ERROR handler.

Same shape as the \`MISSING_USER_DATA\` pair (#80 / #409):

- Widen \`PackageAPIStatusResponse.errorMessageCode\` union.
- Add \`MISSING_ACTIVITY_DATA\` to the error → translation map in \`src/app/onboarding/loading/page.tsx\`.
- Add \`onboarding.loading.missingActivityData\` to en.json:
  > Your Discord export is missing your activity history. When requesting your data again, make sure the \"Activity history\" option is ticked.

Other locales fill in via Crowdin.

Merge order: dumpus-app/dumpus-api#81 → this. Both are harmless to land alone but the runtime/type pair makes the user-visible message right.