### PR TITLE
fix(ios): IAP init order — register products before initialize()

### DIFF
--- a/src/stores/purchases.ts
+++ b/src/stores/purchases.ts
@@ -41,53 +41,76 @@ export const createPurchasesSlice: CreateSlice<PurchasesSlice> = (
       return finish();
     }
 
-    // @ts-ignore
-    await import("cordova-plugin-purchase");
-    const { ProductType, Platform, store } = window.CdvPurchase;
+    try {
+      // @ts-ignore
+      await import("cordova-plugin-purchase");
+      const { ProductType, Platform, store } = window.CdvPurchase;
 
-    await store.initialize();
-    store.register([
-      {
-        id: PRODUCT_SUPPORTER_KEY,
-        type: ProductType.NON_CONSUMABLE,
-        platform: Platform.GOOGLE_PLAY,
-      },
-      {
-        id: PRODUCT_SUPPORTER_KEY,
-        type: ProductType.NON_CONSUMABLE,
-        platform: Platform.APPLE_APPSTORE,
-      },
-    ]);
-    await store.update();
+      // Order matters per the cordova-plugin-purchase v13 README:
+      //   1. register products
+      //   2. attach event handlers
+      //   3. initialize the platform adapters
+      // The previous order (initialize → register → update) worked on
+      // Google Play but on the Apple App Store the adapter queries App
+      // Store Connect for the products list at initialize time. With no
+      // products registered yet, it queried for nothing, store.get(key)
+      // returned undefined, and the dialog showed "Payments not supported"
+      // even though the product (id "supporter", App Store Connect ID
+      // 6451364202) was approved.
+      store.register([
+        {
+          id: PRODUCT_SUPPORTER_KEY,
+          type: ProductType.NON_CONSUMABLE,
+          platform: Platform.GOOGLE_PLAY,
+        },
+        {
+          id: PRODUCT_SUPPORTER_KEY,
+          type: ProductType.NON_CONSUMABLE,
+          platform: Platform.APPLE_APPSTORE,
+        },
+      ]);
 
-    for (const key of PRODUCT_KEYS) {
-      const product = store.get(key);
-      if (product) {
-        set((state) => ({
-          purchases: {
-            ...state.purchases,
-            products: [...state.purchases.products, product],
-          },
-        }));
-      }
-    }
-
-    store.when().approved(async (transaction) => {
-      // Can only be one product bought for now
-      const productID = transaction.products[0].id as ProductKey;
-
-      emitter.emit("purchases:transaction:approved", {
-        key: productID,
+      // Populate the products array reactively as the store loads them
+      // from each platform. productUpdated fires once per product per
+      // refresh; idempotent guard avoids duplicates.
+      store.when().productUpdated((product) => {
+        set((state) => {
+          if (state.purchases.products.some((p) => p.id === product.id)) {
+            return state;
+          }
+          return {
+            purchases: {
+              ...state.purchases,
+              products: [...state.purchases.products, product],
+            },
+          };
+        });
       });
-      get().config.setPremium(true);
-      get().ui.setShowInAppPurchasesDialog(false);
-      if (get().ui.showInAppPurchasesDialog || get().purchases.restoring) {
-        notify(productID);
-      }
-      await transaction.finish();
-    });
 
-    set((state) => ({ purchases: { ...state.purchases, supported: true } }));
+      store.when().approved(async (transaction) => {
+        // Can only be one product bought for now
+        const productID = transaction.products[0].id as ProductKey;
+
+        emitter.emit("purchases:transaction:approved", {
+          key: productID,
+        });
+        get().config.setPremium(true);
+        get().ui.setShowInAppPurchasesDialog(false);
+        if (get().ui.showInAppPurchasesDialog || get().purchases.restoring) {
+          notify(productID);
+        }
+        await transaction.finish();
+      });
+
+      await store.initialize();
+
+      set((state) => ({ purchases: { ...state.purchases, supported: true } }));
+    } catch (err) {
+      // Surface init failures in the device console so the next time
+      // someone reports "Payments not supported" we have a real reason
+      // to work from instead of guessing. supported stays false.
+      console.error("[purchases] init failed:", err);
+    }
     finish();
   },
   restorePurchases: async () => {


### PR DESCRIPTION
## Summary

A user reported \"Payments not supported\" on iOS even with the App Store Connect product (id \`supporter\`, internal ID \`6451364202\`) **approved**.

## Root cause

The current \`stores/purchases.ts\` calls:

1. \`await store.initialize()\`
2. \`store.register([...])\`
3. \`await store.update()\`

The cordova-plugin-purchase v13 README is explicit about the correct order:

\`\`\`js
// 1. register
store.register([...]);
// 2. event handlers
store.when().approved(...);
// 3. initialize (this is what queries the platform store for the registered products)
await store.initialize([...]);
\`\`\`

The Apple App Store adapter queries App Store Connect for the products list **at initialize time**, using whatever's registered then. With nothing registered yet, it queried for nothing → \`store.get('supporter')\` returned \`undefined\` → \`products\` array stayed empty → the dialog's \`supported && hasProducts\` guard rendered the \"not supported\" branch.

Google Play's adapter is more forgiving — \`store.update()\` afterwards triggers a re-fetch and \`store.get(key)\` returns the product, which is why this worked on Android.

## Fix

- **Reorder**: register → event handlers → initialize.
- Switch product population from a synchronous post-update \`store.get()\` loop to listening on the \`productUpdated\` event (with idempotent dedup by \`product.id\`). That's how the v13 plugin emits product info from each adapter.
- **Wrap in try/catch** + \`console.error\` so any future init failure surfaces a real reason in the device console (Safari → Develop → [iPhone] → [App webview]) instead of the silent partial state we had before.
- \`finish()\` still always runs after the try/catch so \`initialized=true\` regardless. Prevents init() being retried in a loop on permanent failures.

## Test plan

- [ ] Merge → CI deploys.
- [ ] Build for iOS, install on a device or TestFlight.
- [ ] Open the supporter dialog. Should now show the \$1.99 \"Early Supporter\" pricing card instead of \"Payments not supported\".
- [ ] Tap purchase → sandbox flow completes → \`config.premium\` becomes true.
- [ ] No regression on Android (same plugin, same registered products, just a different documented call order).