### PR TITLE
chore(release): 1.0.11 (re-issue)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.dumpus.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 29
-        versionName "1.0.10"
+        versionCode 30
+        versionName "1.0.11"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQ53Y973KM;
 				INFOPLIST_FILE = App/Info.plist;
@@ -376,13 +376,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CQ53Y973KM;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = app.dumpus.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumpus-app",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "license": "GPL-3.0",
   "packageManager": "pnpm@9.14.2",


### PR DESCRIPTION
Same misfire pattern as v1.0.10 last week:

- Tag \`v1.0.11\` points to \`c7dc5c6\` (the iOS IAP fix merge), where \`package.json\` is still at **1.0.10**.
- Release artifacts are stamped \`dumpus-app_1.0.10_*\`.
- iOS Deployment failed with \`The version number has been previously used\` — App Store Connect rejected because the AAB inside is marketing version 1.0.10, and 1.0.10 is already on the store.

The release-bump commit went somewhere that never reached main. This PR re-runs \`pnpm release:patch\` from current main and brings it onto a clean branch.

| | Before | After |
|---|---|---|
| \`package.json\` | 1.0.10 | **1.0.11** |
| Android versionName | 1.0.10 | **1.0.11** |
| Android versionCode | 29 | **30** |
| iOS MARKETING_VERSION | 1.0.10 | **1.0.11** |
| iOS CURRENT_PROJECT_VERSION | 29 | **30** |

After merge:

\`\`\`bash
gh release delete v1.0.11 --repo dumpus-app/dumpus-app --yes
git push --delete origin v1.0.11
git tag -d v1.0.11

git fetch origin main
gh release create v1.0.11 --target main --generate-notes
\`\`\`

This re-fires the platform build workflows against the new main HEAD, producing artifacts at the right version. The iOS Deployment workflow should succeed because the AAB will now be marketing version 1.0.11 (not 1.0.10).